### PR TITLE
i18nのライブラリ導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,9 @@ gem 'bootsnap', require: false
 # Authentication
 gem 'sorcery'
 
+# i18n
+gem 'rails-i18n', '~> 7.0.0'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri windows]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,6 +210,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.8)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.1.2)
       actionpack (= 7.1.2)
       activesupport (= 7.1.2)
@@ -326,6 +329,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.2)
+  rails-i18n (~> 7.0.0)
   rspec-rails
   rubocop
   rubocop-rails

--- a/app/views/user_sessions/_form.html.erb
+++ b/app/views/user_sessions/_form.html.erb
@@ -1,10 +1,10 @@
 <%= form_with url: login_path, method: :post do |f| %>
   <div class="field">
-    <%= f.label :email %><br />
+    <%= f.label :email, User.human_attribute_name(:email) %><br />
     <%= f.text_field :email %>
   </div>
   <div class="field">
-    <%= f.label :password %><br />
+    <%= f.label :password, User.human_attribute_name(:password) %><br />
     <%= f.password_field :password %>
   </div>
   <div class="actions mt-4">

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,6 +39,9 @@ module MeetupHub
     # Don't generate system test files.
     config.generators.system_tests = nil
 
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+
     config.generators do |g|
       g.helper false
       g.test_framework :rspec,

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,9 @@
+ja:
+  activerecord:
+    models:
+      user: "ユーザー"
+    attributes:
+      user:
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "パスワード（確認）"


### PR DESCRIPTION
# 背景
#19 
日本語化するため、i18n関連のライブラリを導入する

# やったこと
- `rails-i18n`をインストール、基本設定
- `config/locales/ja.yml`を作成

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- アプリケーションに国際化サポートを追加し、日本語をデフォルトのロケールとして設定しました。

- **改善点**
	- ユーザーセッションフォームのラベル生成を改善し、Eメールとパスワードフィールドに対して `User.human_attribute_name` を使用するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->