### PR TITLE
GA4用のタグを追加

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,14 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6BKP834GFE"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-6BKP834GFE');
+    </script>
   </head>
 
   <body>


### PR DESCRIPTION
# 背景
#20 
どの程度アクセスがあったかをGA上で計測できるようにする。

# やったこと
- アプリ用のプロパティを作成し、タグをHTML上に追加した。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Google Analyticsの追跡コードを追加して、ページビューとユーザーのインタラクションを追跡します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->