### PR TITLE
ログイン画面と新規登録画面のデザイン修正＋エラー時の挙動修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,9 +56,9 @@ gem 'rails-i18n', '~> 7.0.0'
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri windows]
-  gem 'pry-byebug'
   gem 'factory_bot_rails'
   gem 'faker'
+  gem 'pry-byebug'
   gem 'rspec-rails'
   gem 'rubocop', require: false
   gem 'rubocop-rails', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ gem 'rails-i18n', '~> 7.0.0'
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri windows]
+  gem 'pry-rails'
   gem 'factory_bot_rails'
   gem 'faker'
   gem 'rspec-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem 'rails-i18n', '~> 7.0.0'
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri windows]
-  gem 'pry-rails'
+  gem 'pry-byebug'
   gem 'factory_bot_rails'
   gem 'faker'
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
     bootsnap (1.17.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
@@ -181,8 +182,9 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-rails (0.3.9)
-      pry (>= 0.10.4)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
     psych (5.1.2)
       stringio
     puma (6.4.2)
@@ -334,7 +336,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   pg (~> 1.1)
-  pry-rails
+  pry-byebug
   puma (>= 5.0)
   rails (~> 7.1.2)
   rails-i18n (~> 7.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
     bootsnap (1.17.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -135,6 +136,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.2)
+    method_source (1.0.0)
     mini_mime (1.1.5)
     minitest (5.20.0)
     msgpack (1.7.2)
@@ -176,6 +178,11 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     psych (5.1.2)
       stringio
     puma (6.4.2)
@@ -327,6 +334,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   pg (~> 1.1)
+  pry-rails
   puma (>= 5.0)
   rails (~> 7.1.2)
   rails-i18n (~> 7.0.0)

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,14 +1,15 @@
 class UserSessionsController < ApplicationController
   def new
+    @user = User.new
   end
 
   def create
     @user = login(params[:email], params[:password])
-
     if @user
       redirect_back_or_to root_path
     else
-      render action: 'new'
+      @errors = ['メールアドレスまたはパスワードが間違っています。']
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -8,7 +8,7 @@ class UserSessionsController < ApplicationController
     if @user
       redirect_back_or_to root_path
     else
-      @errors = ['メールアドレスまたはパスワードが間違っています。']
+      @errors = [t('errors.messages.invalid_login')]
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
     if @user.save
       redirect_to login_path
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
   </head>
 
   <body>
-    <main class="container mx-auto mt-28 px-5">
+    <main class="flex justify-center content-center mt-28 px-5 w-screen">
       <%= yield %>
     </main>
   </body>

--- a/app/views/user_sessions/_form.html.erb
+++ b/app/views/user_sessions/_form.html.erb
@@ -1,5 +1,13 @@
 <%= form_with url: login_path, method: :post do |f| %>
-	<div class="space-y-4">
+  <% if @errors.present? %>
+    <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 mb-6 rounded relative" role="alert">
+      <strong class="font-bold">ログインに失敗しました。<br></strong>
+      <% @errors.each do |error| %>
+        <span class="block sm:inline"><%= error %></span>
+      <% end %>
+    </div>
+  <% end %>
+  <div class="space-y-4">
     <div class="field">
       <%= f.label :email, User.human_attribute_name(:email), class: "mb-2 text-sm"  %><br />
       <%= f.text_field :email, placeholder: "meetup-hub@example.com", class: "w-full px-3 py-2 border rounded-md" %>
@@ -10,6 +18,6 @@
     </div>
   </div>
   <div class="actions mt-8">
-    <%= f.submit "ログイン", class: "w-full inline-block bg-gray-700 hover:bg-gray-900 text-white font-bold py-2 px-4 rounded" %>
+    <%= f.submit "ログイン", class: "w-full inline-block bg-gray-700 hover:bg-gray-900 text-white font-bold py-2 px-4 rounded cursor-pointer" %>
   </div>
 <% end %>

--- a/app/views/user_sessions/_form.html.erb
+++ b/app/views/user_sessions/_form.html.erb
@@ -1,13 +1,15 @@
 <%= form_with url: login_path, method: :post do |f| %>
-  <div class="field">
-    <%= f.label :email, User.human_attribute_name(:email) %><br />
-    <%= f.text_field :email %>
+	<div class="space-y-4">
+    <div class="field">
+      <%= f.label :email, User.human_attribute_name(:email), class: "mb-2 text-sm"  %><br />
+      <%= f.text_field :email, placeholder: "meetup-hub@example.com", class: "w-full px-3 py-2 border rounded-md" %>
+    </div>
+    <div class="field">
+      <%= f.label :password, User.human_attribute_name(:password), class: "mb-2 text-sm" %><br />
+      <%= f.password_field :password, placeholder: "********", class: "w-full px-3 py-2 border rounded-md"  %>
+    </div>
   </div>
-  <div class="field">
-    <%= f.label :password, User.human_attribute_name(:password) %><br />
-    <%= f.password_field :password %>
-  </div>
-  <div class="actions mt-4">
-    <%= f.submit "ログイン" %>
+  <div class="actions mt-8">
+    <%= f.submit "ログイン", class: "w-full inline-block bg-gray-700 hover:bg-gray-900 text-white font-bold py-2 px-4 rounded" %>
   </div>
 <% end %>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,5 +1,10 @@
-<h1 class="text-4xl font-bold">ログイン</h1>
-
-<%= render 'form' %>
-
-<%= link_to '戻る', root_path %>
+<div class="flex flex-col w-full max-w-lg p-6 rounded-md sm:p-10 bg-gray-100">
+  <div class="mb-8 text-center">
+    <h1 class="my-3 text-4xl font-bold">ログイン</h1>
+  </div>
+  <%= render 'form' %>
+  <div class="actions flex flex-col mt-6">
+    <%= link_to 'アカウントをお持ちでない方はこちら', new_user_path, class: "mb-4 text-gray-700 hover:underline" %>
+    <%= link_to '戻る', root_path, class: "text-gray-700 hover:underline" %>
+  </div>
+</div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,4 +1,13 @@
 <%= form_with model: @user, local: true do |f| %>
+  <%- pp @user&.errors.full_messages %>
+  <% if @user.errors.present? %>
+    <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 mb-6 rounded relative" role="alert">
+      <strong class="font-bold">登録に失敗しました。<br></strong>
+      <% @user.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </div>
+  <% end %>
 	<div class="space-y-4">
     <div class="field">
       <%= f.label :email, class: "mb-2 text-sm" %><br />

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,18 +1,19 @@
 <%= form_with model: @user, local: true do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.text_field :email %>
+	<div class="space-y-4">
+    <div class="field">
+      <%= f.label :email, class: "mb-2 text-sm" %><br />
+      <%= f.text_field :email, placeholder: "meetup-hub@example.com", class: "w-full px-3 py-2 border rounded-md" %>
+    </div>
+    <div class="field">
+      <%= f.label :password, class: "mb-2 text-sm" %><br />
+      <%= f.password_field :password, placeholder: "********", class: "w-full px-3 py-2 border rounded-md" %>
+    </div>
+    <div class="field">
+      <%= f.label :password_confirmation, class: "mb-4 text-sm" %><br />
+      <%= f.password_field :password_confirmation, placeholder: "********", class: "w-full px-3 py-2 border rounded-md"  %>
+    </div>
   </div>
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password %>
-  </div>
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation %>
-  </div>
-  <div class="actions">
-    <%= f.submit "新規登録" %>
+  <div class="actions mt-8">
+    <%= f.submit "新規登録", class: "w-full inline-block bg-gray-700 hover:bg-gray-900 text-white font-bold py-2 px-4 rounded" %>
   </div>
 <% end %>
-

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,5 +1,10 @@
-<h1 class="text-4xl font-bold">新規登録</h1>
-
-<%= render 'form' %>
-
-<%= link_to '戻る', root_path %>
+<div class="flex flex-col w-full max-w-lg p-6 rounded-md sm:p-10 bg-gray-100">
+  <div class="mb-8 text-center">
+    <h1 class="my-3 text-4xl font-bold">新規登録</h1>
+  </div>
+  <%= render 'form' %>
+  <div class="actions flex flex-col mt-6">
+    <%= link_to 'アカウントをお持ちの方はこちら', login_path, class: "mb-4 text-gray-700 hover:underline" %>
+    <%= link_to '戻る', root_path, class: "text-gray-700 hover:underline" %>
+  </div>
+</div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,3 +7,6 @@ ja:
         email: "メールアドレス"
         password: "パスワード"
         password_confirmation: "パスワード（確認）"
+  errors:
+    messages:
+      invalid_login: "メールアドレスまたはパスワードが正しくありません。"

--- a/spec/requests/user_sessions_spec.rb
+++ b/spec/requests/user_sessions_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'UserSessions', type: :request do
-  let!(:user) { create(:user) }
+  let!(:user) { create(:user, password: 'password') }
   describe 'GET /new' do
     it 'HTTPステータスが200であること' do
       get login_path
@@ -12,15 +12,15 @@ RSpec.describe 'UserSessions', type: :request do
   describe 'POST /create' do
     context 'パラメータが妥当な場合' do
       it 'リクエストが成功すること' do
-        post login_path, params: { email: user.email, password: user.password }
-        expect(response.status).to eq 200
+        post login_path, params: { email: user.email, password: 'password' }
+        expect(response.status).to eq 302
       end
     end
 
     context 'パラメータが不正な場合' do
-      it 'リクエストが成功すること' do
+      it 'リクエストが失敗すること' do
         post login_path, params: { email: '', password: '' }
-        expect(response.status).to eq 200
+        expect(response.status).to eq 422
       end
     end
   end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe 'Users', type: :request do
     end
 
     context 'パラメータが不正な場合' do
-      it 'リクエストが成功すること' do
+      it 'リクエストが失敗すること' do
         post users_path, params: { user: attributes_for(:user, email: '') }
-        expect(response.status).to eq 200
+        expect(response.status).to eq 422
       end
 
       it 'ユーザーが登録されないこと' do


### PR DESCRIPTION
# 背景
#18 
ログイン画面と新規登録画面のデザインをある程度整える。

# やったこと
- 新規登録画面のデザイン修正
- ログイン画面のデザイン修正
- 新規登録・ログイン時に失敗した際、エラーメッセージを表示するように修正
- `pry-byebug`を導入

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ユーザーログインフォームにエラーメッセージを表示する機能を追加。
	- ユーザー登録ページとログインページに新しいナビゲーションリンクを追加。

- **バグ修正**
	- ログイン失敗時のエラーハンドリングを改善し、適切なステータスコードを返すように変更。
	- ユーザー保存に失敗した際に、適切なステータスコードを返すように変更。

- **デザイン更新**
	- アプリケーションのメインコンテナのレイアウトをフレックスボックスを使用して中央揃えに変更。
	- ユーザーログインフォームとユーザー登録フォームのスタイリングを改善。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->